### PR TITLE
Adding missing 'import time'

### DIFF
--- a/pandatools/PBookCore.py
+++ b/pandatools/PBookCore.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+import time
 import commands
 import sys
 # tweak sys.path since threading cannot be imported with Athena 15 on SLC5/64


### PR DESCRIPTION
There was an import line missing when we migrated PBookCore. This adds it back in.
As far as I can tell it only affected the killAndRetry command which is probably why it was missed in our tests.