### PR TITLE
fix: Use build_requires in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 provides = panda-client
 release = 1
 packager = Panda Team <hn-atlas-panda-pathena@cern.ch>
-build-requires = python-devel
+build_requires = python-devel
 requires = python
 
 [install]


### PR DESCRIPTION
In the `sdist` creation phase of the build there is currently the warning:

```console
$ python setup.py sdist
/home/runner/work/panda-client/panda-client/setup.py:6: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils
/opt/hostedtoolcache/Python/3.10.0/x64/lib/python3.10/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'build-requires' will not be supported in future versions. Please use the underscore name 'build_requires' instead
  warnings.warn(
...
```

https://github.com/PanDAWMS/panda-client/blob/3c2aee0d6f8cfeed64c46556b069f9564dd27478/setup.cfg#L3-L7

This PR addresses the `setuptools` warning RE: using `build_requires` in `setup.cfg`.

The `distuitls` warning should be addressed in a separate PR.