### PR TITLE
ci: Update publishing workflow and add checks

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,26 +1,47 @@
 name: Upload Python Package
 
 on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build twine
+        python -m pip list
+
+    - name: Build a sdist
       run: |
-        python setup.py sdist
-        twine upload dist/*
+        python -m build --sdist .
+
+    - name: Verify the distribution
+      run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/panda-client-*.tar.gz
+
+    - name: Publish distribution to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'PanDAWMS/panda-client'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,8 @@ packager = Panda Team <hn-atlas-panda-pathena@cern.ch>
 build_requires = python-devel
 requires = python
 
+[bdist_wheel]
+universal=1
+
 [install]
 record = install_record.txt

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,18 @@ setup(
     author_email='atlas-adc-panda@cern.ch',
     url='https://panda-wms.readthedocs.io/en/latest/',
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
 
     # optional pip dependencies
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -144,12 +144,15 @@ class install_data_panda (install_data_org):
             except Exception:
                 pass
 
+with open('README.md', 'r', encoding='utf-8') as description_file:
+    long_description = description_file.read()
 
 setup(
     name="panda-client",
     version=release_version,
-    description=' PanDA Client Package',
-    long_description='''This package contains PanDA Client Tools''',
+    description='PanDA Client Package',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     license='GPL',
     author='PanDA Team',
     author_email='atlas-adc-panda@cern.ch',

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ setup(
     author='PanDA Team',
     author_email='atlas-adc-panda@cern.ch',
     url='https://panda-wms.readthedocs.io/en/latest/',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 
     # optional pip dependencies
     extras_require={


### PR DESCRIPTION
This PR does a few things to ensure that valid sdists and wheels are being built.

## GitHub Actions workflow

* Update the GHA action versions for speed and support

* Use `build` to build a sdist ~~and a wheel~~ as calling `python setup.py` directly is considered deprecated behavior by the PyPA. c.f. https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for a very detailed summary

* Use `tarfile` ~~and `zipfile` modules~~module to list out the contents of the built sdist ~~and wheel~~ to act as a visual check

* Run the CI on push events to master and pull_request events targeting master and on workflow_dispatch events to check that the sdist ~~and wheel~~ can be built properly without errors. Deploy only on release events once the release has been published to GitHub (which **requires creating a [GitHub release](https://github.com/PanDAWMS/panda-client/releases) from a tag**) to allow for additional stages of testing if something goes wrong, helping to avoid broken packages getting up onto PyPI. Additionally, ensure that publishing can only occur from the PanDAWMS/panda-client GitHub repo.

Here's an example on my fork:
![run_example](https://user-images.githubusercontent.com/5142394/141855462-24d12e60-55e5-4013-bfd1-696ada2d489b.png)

## Build metadata in setup.py and setup.cfg

* Set python_requires to Python 2.7 or 3.5+
   - Having a lower bound on python_requires is critical to ensure that pip can properly resolve and install the package in the future. If there is no python_requires then when compatibility with a version is broken (e.g. the inevitable and hopefully near-term dropping of Python 2) pip will not know that the version is broken on that Python and will attempt to install a broken release. Setting a lower bond on python_requires and carefully monitoring and bumping it through testing is critical.

* Set universal wheel as Python 2 still supported
   - To let pip know that the none-any wheel is installable across both Python 2 and Python 3 set the bdist_wheel universal option to True which will result in built wheels having a name pattern of `panda_client-X.Y.Z-py2.py3-none-any.whl`. Without this option the wheel name is `panda_client-X.Y.Z-py3-none-any.whl`. Note that this option should be removed once Python 2 support is dropped.

* Avoid warnings on long description type
   - c.f. https://packaging.python.org/tutorials/packaging-projects/