### PR TITLE
Fix str-int comparison when using nGBPerMergeJob

### DIFF
--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -40,7 +40,7 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
     sys.argv.insert(0, 'prun')
 
     usage = """prun [options]
-    
+
       HowTo is available at https://panda-wms.readthedocs.io/en/latest/client/prun.html"""
 
     examples = """Examples:
@@ -100,7 +100,7 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
 
     usage_containerJob="""Visit the following wiki page for examples:
       https://twiki.cern.ch/twiki/bin/view/PanDA/PandaRun#Run_user_containers_jobs
-    
+
     Please test the job interactively first prior to submitting to the grid.
     Check the following on how to test container job interactively:
       https://twiki.cern.ch/twiki/bin/viewauth/AtlasComputing/SingularityInAtlas
@@ -1867,8 +1867,22 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
         taskParamMap['mergeSpec']['useLocalIO'] = 1
         taskParamMap['mergeSpec']['jobParameters'] = jobParameters
         taskParamMap['mergeOutput'] = True
-        if options.nGBPerMergeJob > 0:
-            taskParamMap['nGBPerMergeJob'] = options.nGBPerMergeJob
+
+        # check nGBPerJob
+        if not options.nGBPerMergeJob in [-1,'MAX']:
+            # convert to int
+            try:
+                options.nGBPerMergeJob = int(options.nGBPerMergeJob)
+            except Exception:
+                tmpLog.error("--nGBPerMergeJob must be an integer")
+                sys.exit(EC_Config)
+            # check negative
+            if options.nGBPerMergeJob <= 0:
+                tmpLog.error("--nGBPerMergeJob must be positive")
+                sys.exit(EC_Config)
+
+            if options.nGBPerMergeJob > 0:
+                taskParamMap['nGBPerMergeJob'] = options.nGBPerMergeJob
 
 
     #####################################################################

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1872,7 +1872,8 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
         if not options.nGBPerMergeJob in [-1,'MAX']:
             # convert to int
             try:
-                options.nGBPerMergeJob = int(options.nGBPerMergeJob)
+                if options.nGBPerJob != 'MAX':
+                    options.nGBPerMergeJob = int(options.nGBPerMergeJob)
             except Exception:
                 tmpLog.error("--nGBPerMergeJob must be an integer")
                 sys.exit(EC_Config)

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1872,7 +1872,7 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
         if not options.nGBPerMergeJob in [-1,'MAX']:
             # convert to int
             try:
-                if options.nGBPerJob != 'MAX':
+                if options.nGBPerMergeJob != 'MAX':
                     options.nGBPerMergeJob = int(options.nGBPerMergeJob)
             except Exception:
                 tmpLog.error("--nGBPerMergeJob must be an integer")


### PR DESCRIPTION
Hi, 

I ran into an issue when using `prun` with the option `--nGBPerMergeJob=X`, where `panda-client` throws the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/x86_64/PandaClient/1.5.42/lib/python3.9/site-packages/pandaclient/PrunScript.py", line 1870, in main
    if options.nGBPerMergeJob > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
```

As you can see I am using the panda-client deployed on CVMFS via the CERN, ATLAS environment. This iuses the most recent panda-client version (`1.5.42`).

I ran into this issue when I ran the command:

```
prun --exec 'python3 sklim.py infile_list.txt --inds myds.root --syst --datafiles ./mydata/ --verbosity 4 -nt 10 ' --writeInputToTxt '%IN':infile_list.txt --inDS myds.root --outDS myds_L2_v3Test.root --nGBPerJob=10 --memory=3000 --outputs output.root  --inTarBall tHSkimmer_gridball.tgz --match '*root*' --noCompile --rootVer=6.28/00 --cmtConfig=x86_64-centos7-gcc11-opt --noEmail --noBuild --mergeOutput --nGBPerMergeJob=20
```

This PR simply treats the `nGBPerMergeJob` option the same way `nGBPerJob` option works, turning the value of the argument into an integer before any checks on it. 

I'm really surprised that this was not flagged in the past since a git blame shows last change to this part of the code is 2 years ago. So maybe I'm missing something?