### PR TITLE
Improve tarball creation robustness w.r.t transient errors & speed up tarball creation

### DIFF
--- a/pandaclient/AthenaUtils.py
+++ b/pandaclient/AthenaUtils.py
@@ -10,7 +10,7 @@ from . import Client
 # error code
 EC_Config    = 10
 EC_Archive   = 60
-
+ 
 # get CMT projects
 def getCmtProjects(dir='.'):
     # cmt or cmake

--- a/pandaclient/AthenaUtils.py
+++ b/pandaclient/AthenaUtils.py
@@ -10,7 +10,7 @@ from . import Client
 # error code
 EC_Config    = 10
 EC_Archive   = 60
- 
+
 # get CMT projects
 def getCmtProjects(dir='.'):
     # cmt or cmake

--- a/pandaclient/MiscUtils.py
+++ b/pandaclient/MiscUtils.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import os
 import json
 import uuid
@@ -151,6 +152,47 @@ def commands_get_status_output(com):
 
 def commands_get_output(com):
     return commands_get_status_output(com)[1]
+
+def commands_failOnNonZeroExitStatus(
+    com, errorStatusOnFailure,
+    verboseCmd=False,verboseOutputCmd=False,
+    logger=None,logMsg="",errorLogMsg=""):
+    
+    # add log message if logger and log message have been provided 
+    if logger is not None and logMsg != "":
+        logger.debug(logMsg)
+    
+    # print command if verbose
+    if verboseCmd:
+        print(com)
+    
+    # execute command, get status code and message printed by the command 
+    status,data = commands_get_status_output(com)
+    
+    # fail for non zero exit status 
+    if status != 0:
+        # print error message before failing
+        print(data)
+        # report error message if logger and log message have been provided 
+        if logger is not None and errorLogMsg != "":
+            logger.error(errorLogMsg)
+        
+        if type(errorStatusOnFailure) == int:
+            # use error status provided to the function
+            sys.exit(errorStatusOnFailure)
+        elif errorStatusOnFailure == "sameAsStatus":
+            # use error status exit code returned 
+            # by the execution of the command
+            sys.exit(status)
+        else: 
+            # default exit status otherwise
+            sys.exit(1)
+    
+    # print command output message if verbose
+    if verboseOutputCmd and data != "":
+        print(data)
+
+    return status,data
 
 
 # decorator to run with the original environment


### PR DESCRIPTION
Hi @tmaeno, 

I am creating this MR which I think could improve the `prun` code and would allow increasing its stability w.r.t. transient issues. 

Tagging also for information @krasznaa

**NB:** **I could not test the changes proposed in this MR below because I do not know how to do so on `lxplus`**  
But I believe they should work.  Please let me know if you want me to test it I am willing to help but I would just need a pointer to instructions on how to do so. 

Many thanks in advance,
Best,
Romain Bouquet
 
### Explanation of the issue addressed in this MR

Following the important changes concerning `cpack` (discussed in the following email thread, [link](https://login.cern.ch/adfs/ls/?wa=wsignin1.0&wtrealm=https%3a%2f%2fgroups.cern.ch%2f_trust%2f&wctx=https%3a%2f%2fgroups.cern.ch%2fgroup%2fhn-atlas-PATHelp%2f_layouts%2fAuthenticate.aspx%3fSource%3d%252Fgroup%252Fhn%252Datlas%252DPATHelp%252FLists%252FArchive%252FFlat%252Easpx%253FRootFolder%253D%25252Fgroup%25252Fhn%25252Datlas%25252DPATHelp%25252FLists%25252FArchive%25252FIncrease%252520grid%252520job%252520submission%252520stability%252520problems%252520with%252520tarball%252520creation%252520when%252520using%252520Prun%2526FolderCTID%253D0x0120020084D7E80CB0C3394A8D54EF07C309B044)) concerning missing files in the tarball,   
 I figure out there was also an issue in the `prun` code with the following reasoning:  
* `cpack`  enables to include the code from the build directory into the tarball   
  --> most of the issues we had where related to `cpack` and should be now fixed. 
* But with our framework we also include external files e.g. some text file and one root file that are put in the submission directory. Those files have also been observed to be sometimes missing in the tarball sent to the grid.  
--> this means that the code related to the `prun` command is "responsible" for those cases as those files are indeed added to the tarball by the `prun` code (and not `cpack`). 

After some investigation I found out that the function `commands_get_output` is indeed silencing errors, it does not exit if the command executed is failing. 
This function is used in several places in the `AthenaUtils.py` script where basically the files mentionned in the second bullet above are added to the tarball.  
The error not reported could for instance be due to `AFS` or `EOS` transient issues or exceeding space quota.

### Solution to the issue proposed in this MR

To counter that issue I am introducing in this MR a new function called `commands_failOnNonZeroExitStatus`.   
This function will fail if the return exit code of the command executed is different from `0`. 
I thus replaced the `commands_get_output` by the  `commands_failOnNonZeroExitStatus` function when the command was involving the `tar` command. This should make the `prun`  (and `pathena`) code robust to transient issues as the code will fail instead of silencing such errors. 

----
In addition to those changes, 
I also saw that once the `.tar.gz` archive file had been created by `cpack` we were executing the following command 
```
comStr = 'tar xfz {0}.gz; tar cf {0} usr > /dev/null 2>&1; rm -rf usr _CPack_Packages {0}.gz'.format(
            archiveName)
```
which basically transform the `.tar.gz` archive  into the `.tar` archive. 
It involves 3 steps: 
* untarring the `tar.gz` which gives the `usr` directory 
* tarring the `usr` directory which gives the `.tar` archive 
* cleaning the: 
  * `usr` directory 
  * the `.tar.gz` archive 
  * the `_CPack_Packages` which is created by `cpack`

This is time consumming and is requiring some storage space as the `usr` and `tar.gz` can take some space (for us `500Mb`  and `300 Mb`). 
The command can simply be replace by 
```
comStr = 'gzip -d {0}.gz && rm -rf _CPack_Packages'.format(archiveName)
```
 * `gzip` will transform directly the `.tar.gz` into the `.tar` archive 
 * It saves some time for the `.tar` file creation 
 * It does not require deleting the `.tar.gz`  archive and the `usr` directory (since that directory is not created) 
 

 
 
  