### PR TITLE
Update --architecture help text with new GPU brokerage filters

### DIFF
--- a/pandaclient/PathenaScript.py
+++ b/pandaclient/PathenaScript.py
@@ -1249,8 +1249,9 @@ group_containerJob.add_argument(
     "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
     "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
     "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-    "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
-    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data. "
+    "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+    "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data. "
     "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
 )
 group_build.add_argument("-3", action="store_true", dest="python3", default=False, help="Use python3")

--- a/pandaclient/PathenaScript.py
+++ b/pandaclient/PathenaScript.py
@@ -1249,9 +1249,9 @@ group_containerJob.add_argument(
     "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
     "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
     "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-    "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+    "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
     "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
-    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data. "
+    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "
     "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
 )
 group_build.add_argument("-3", action="store_true", dest="python3", default=False, help="Use python3")

--- a/pandaclient/PathenaScript.py
+++ b/pandaclient/PathenaScript.py
@@ -1245,10 +1245,12 @@ group_containerJob.add_argument(
     "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
     "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
     "CPU with avx2 support and nvidia GPU. "
-    "This option also allows to specify a json-serialized dictionary, where the gpu_spec model field "
-    'accepts either a plain regexp string for inclusion (e.g., {"model": ".*A100.*"} to require an A100), '
-    'or a dict with pattern and excl fields for exclusion (e.g., {"model": {"pattern": ".*P100.*", "excl": true}} to exclude P100 queues). '
-    "Matching is case-insensitive. Queues that do not publish model info in CRIC are skipped for any model constraint. "
+    "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
+    "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
+    "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
+    "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+    "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
+    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data. "
     "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
 )
 group_build.add_argument("-3", action="store_true", dest="python3", default=False, help="Use python3")

--- a/pandaclient/PathenaScript.py
+++ b/pandaclient/PathenaScript.py
@@ -1248,7 +1248,7 @@ group_containerJob.add_argument(
     "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
     "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
     "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
-    "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+    "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
     "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
     "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
     "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "

--- a/pandaclient/PhpoScript.py
+++ b/pandaclient/PhpoScript.py
@@ -132,9 +132,9 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
                                    "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
                                    "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
                                    "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-                                   "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+                                   "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
                                    "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
-                                   "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data.")
+                                   "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data.")
     group_config.add_argument('--segmentSpecFile', action='store', dest='segmentSpecFile', default=None,
                               help='External json filename to define segments for segmented HPO which has one model '
                                    'for each segment to be optimized independently. The file '

--- a/pandaclient/PhpoScript.py
+++ b/pandaclient/PhpoScript.py
@@ -131,7 +131,7 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
                                    "The json-serialized dictionary format supports: "
                                    "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
                                    "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
-                                   "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+                                   "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
                                    "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
                                    "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
                                    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data.")

--- a/pandaclient/PhpoScript.py
+++ b/pandaclient/PhpoScript.py
@@ -132,8 +132,9 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
                                    "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
                                    "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
                                    "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-                                   "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
-                                   "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data.")
+                                   "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+                                   "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+                                   "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data.")
     group_config.add_argument('--segmentSpecFile', action='store', dest='segmentSpecFile', default=None,
                               help='External json filename to define segments for segmented HPO which has one model '
                                    'for each segment to be optimized independently. The file '

--- a/pandaclient/PhpoScript.py
+++ b/pandaclient/PhpoScript.py
@@ -128,10 +128,12 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
                                    "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
                                    "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
                                    "CPU with avx2 support and nvidia GPU. "
-                                   "The json-serialized dictionary format supports regular expressions in the gpu_spec model field: "
-                                   "a plain regexp string for inclusion (e.g., {\"model\": \".*A100.*\"} to require an A100), "
-                                   "or a dict with pattern and excl fields for exclusion (e.g., {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues). "
-                                   "Matching is case-insensitive. Queues that do not publish model info in CRIC are skipped for any model constraint.")
+                                   "The json-serialized dictionary format supports: "
+                                   "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
+                                   "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
+                                   "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+                                   "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
+                                   "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data.")
     group_config.add_argument('--segmentSpecFile', action='store', dest='segmentSpecFile', default=None,
                               help='External json filename to define segments for segmented HPO which has one model '
                                    'for each segment to be optimized independently. The file '

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1056,9 +1056,9 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False, get_options=False)
         "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
         "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
         "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-        "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+        "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
         "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
-        "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data. "
+        "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "
         "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
     )
     group_containerJob.add_argument(

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1055,7 +1055,7 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False, get_options=False)
         "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
         "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
         "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
-        "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+        "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
         "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
         "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
         "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1056,8 +1056,9 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False, get_options=False)
         "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
         "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
         "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
-        "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
-        "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data. "
+        "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}); "
+        "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+        "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version, driver_version) use worker node GPU monitoring data. "
         "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
     )
     group_containerJob.add_argument(

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1052,10 +1052,12 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False, get_options=False)
         "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
         "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
         "CPU with avx2 support and nvidia GPU. "
-        "This option also allows to specify a json-serialized dictionary, where the gpu_spec model field "
-        'accepts either a plain regexp string for inclusion (e.g., {"model": ".*A100.*"} to require an A100), '
-        'or a dict with pattern and excl fields for exclusion (e.g., {"model": {"pattern": ".*P100.*", "excl": true}} to exclude P100 queues). '
-        "Matching is case-insensitive. Queues that do not publish model info in CRIC are skipped for any model constraint. "
+        "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
+        "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
+        "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
+        "vram (minimum GPU memory in MB, e.g. {\"vram\": 40960} for 40 GB); "
+        "architecture (GPU microarch generation, e.g. {\"architecture\": \"Ampere\"} or {\"architecture\": [\"Ampere\", \"Hopper\"]}). "
+        "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, architecture, version) use worker node GPU monitoring data. "
         "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
     )
     group_containerJob.add_argument(


### PR DESCRIPTION
## Summary

Updates the `--architecture` help text in `PrunScript.py`, `PathenaScript.py`, and `PhpoScript.py` to document the new GPU brokerage capabilities introduced in ATLASPANDA-1684:

- `vram`: minimum GPU memory in MB (e.g. `{"vram": 40960}` for 40 GB)
- `architecture`: GPU microarchitecture generation or list (e.g. `{"architecture": "Ampere"}` or `{"architecture": ["Ampere", "Hopper"]}`)
- `version`: minimum CUDA version (e.g. `{"version": ">=12.0"}`)
- Clarifies that CRIC identifies GPU-capable queues and worker node monitoring data is used for attribute matching

## Related PRs

- panda-server #714 (brokerage logic)
- panda-database #132 (MV schema)
- panda-docs (companion PR for full documentation)