### PR TITLE
Document shorthand GPU attributes and driver exact-match in --architecture help

### DIFF
--- a/pandaclient/PathenaScript.py
+++ b/pandaclient/PathenaScript.py
@@ -1245,12 +1245,15 @@ group_containerJob.add_argument(
     "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
     "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
     "CPU with avx2 support and nvidia GPU. "
+    "GPU attributes can also be appended as colon-separated key=value pairs in the shorthand "
+    "(e.g. #&nvidia:vram>=40960:driver>=575.0:model=.*A100.*); supported keys: vram, cuda, uarch, driver, model. "
+    "Use = or == for exact match. "
     "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
     "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
     "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
     "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
     "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
-    "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+    "driver_version (NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"} for minimum or {\"driver_version\": \"==575.51.03\"} for exact). "
     "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "
     "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
 )

--- a/pandaclient/PhpoScript.py
+++ b/pandaclient/PhpoScript.py
@@ -128,12 +128,15 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False):
                                    "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
                                    "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
                                    "CPU with avx2 support and nvidia GPU. "
+                                   "GPU attributes can also be appended as colon-separated key=value pairs in the shorthand "
+                                   "(e.g. #&nvidia:vram>=40960:driver>=575.0:model=.*A100.*); supported keys: vram, cuda, uarch, driver, model. "
+                                   "Use = or == for exact match. "
                                    "The json-serialized dictionary format supports: "
                                    "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
                                    "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
                                    "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
                                    "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
-                                   "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+                                   "driver_version (NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"} for minimum or {\"driver_version\": \"==575.51.03\"} for exact). "
                                    "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data.")
     group_config.add_argument('--segmentSpecFile', action='store', dest='segmentSpecFile', default=None,
                               help='External json filename to define segments for segmented HPO which has one model '

--- a/pandaclient/PrunScript.py
+++ b/pandaclient/PrunScript.py
@@ -1052,12 +1052,15 @@ def main(get_taskparams=False, ext_args=None, dry_mode=False, get_options=False)
         "GPU_spec = vendor<-model>. A wildcard can be used if there is no special "
         "requirement for the attribute. E.g., #x86_64-*-avx2&nvidia to ask for x86_64 "
         "CPU with avx2 support and nvidia GPU. "
+        "GPU attributes can also be appended as colon-separated key=value pairs in the shorthand "
+        "(e.g. #&nvidia:vram>=40960:driver>=575.0:model=.*A100.*); supported keys: vram, cuda, uarch, driver, model. "
+        "Use = or == for exact match. "
         "This option also allows to specify a json-serialized dictionary. The gpu_spec supports: "
         "model (regexp, e.g. {\"model\": \".*A100.*\"} to require an A100, or {\"model\": {\"pattern\": \".*P100.*\", \"excl\": true}} to exclude P100 queues, case-insensitive); "
         "version (minimum CUDA version, e.g. {\"version\": \">=12.0\"}); "
         "vram (GPU memory in MB as an operator-prefixed string, e.g. {\"vram\": \">=40960\"} for at least 40 GB or {\"vram\": \"==40960\"} for exactly 40 GB); "
         "microarchitecture (GPU microarch generation, e.g. {\"microarchitecture\": \"Ampere\"} or {\"microarchitecture\": [\"Ampere\", \"Hopper\"]}); "
-        "driver_version (minimum NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"}). "
+        "driver_version (NVIDIA kernel driver version, e.g. {\"driver_version\": \">=575.0\"} for minimum or {\"driver_version\": \"==575.51.03\"} for exact). "
         "CRIC is used to identify GPU-capable queues; attribute checks (model, vram, microarchitecture, version, driver_version) use worker node GPU monitoring data. "
         "See https://panda-wms.readthedocs.io/en/latest/advanced/brokerage.html#checks-for-cpu-and-or-gpu-hardware",
     )


### PR DESCRIPTION
## Summary

- The `--architecture` help text showed only the legacy `&nvidia` bare shorthand but never mentioned the colon-separated key=value extension (e.g. `#&nvidia:vram>=40960:driver>=575.0:model=.*A100.*`)
- The `driver_version` JSON example only showed `>=`; added an exact-match form (`==575.51.03`)
- Added note that `=` and `==` are both accepted for exact match in the shorthand
- Applied consistently to `prun`, `pathena`, and `phpo`