### PR TITLE
Resolve install paths at runtime instead of baking them in at wheel build time

### DIFF
--- a/pandaclient/panda_jupyter.py
+++ b/pandaclient/panda_jupyter.py
@@ -3,6 +3,7 @@ import getpass
 import os
 import subprocess
 import sys
+import sysconfig
 
 from IPython.core.magic import register_line_magic
 
@@ -21,10 +22,12 @@ def setup():
     parser.read(conf_file)
     section = parser["main"]
 
-    # variables
-    panda_install_scripts = section["PANDA_INSTALL_SCRIPTS"]
-    panda_install_purelib = section["PANDA_INSTALL_PURELIB"]
-    panda_install_dir = section["PANDA_INSTALL_DIR"]
+    # variables: resolved from the current interpreter rather than the config file,
+    # since a wheel-installed panda-client bakes install paths from an isolated build
+    # environment that no longer exists at runtime
+    panda_install_scripts = sysconfig.get_path("scripts")
+    panda_install_purelib = sysconfig.get_path("purelib")
+    panda_install_dir = sysconfig.get_path("data")
 
     # PATH
     paths = os.environ["PATH"].split(":")

--- a/templates/panda_setup.csh.template
+++ b/templates/panda_setup.csh.template
@@ -1,7 +1,7 @@
-setenv PATH @@install_scripts@@:$PATH
+setenv PANDA_SYS `python3 -c "import sysconfig; print(sysconfig.get_path('data'))"`
+setenv PATH `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"`:$PATH
 
 setenv PANDA_CONFIG_ROOT ~/.pathena
-setenv PANDA_SYS @@install_dir@@
 setenv PANDA_PYTHONPATH `bash ${PANDA_SYS}/etc/panda/site_path.sh`
 
 if ($?PYTHONPATH) then

--- a/templates/panda_setup.csh.template
+++ b/templates/panda_setup.csh.template
@@ -1,5 +1,18 @@
-setenv PANDA_SYS `python3 -c "import sysconfig; print(sysconfig.get_path('data'))"`
-setenv PATH `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"`:$PATH
+# prefer the python of an active virtualenv/conda env over a bare "python3" on
+# PATH, so this doesn't silently pick up a different install than the one this
+# file actually belongs to (matches the interpreter-selection order functions.sh
+# already uses for running panda-client commands)
+if ($?VIRTUAL_ENV) then
+    set _panda_python = ${VIRTUAL_ENV}/bin/python3
+else if ($?CONDA_PREFIX) then
+    set _panda_python = ${CONDA_PREFIX}/bin/python3
+else
+    set _panda_python = python3
+endif
+
+setenv PANDA_SYS `${_panda_python} -c "import sysconfig; print(sysconfig.get_path('data'))"`
+setenv PATH `${_panda_python} -c "import sysconfig; print(sysconfig.get_path('scripts'))"`:$PATH
+unset _panda_python
 
 setenv PANDA_CONFIG_ROOT ~/.pathena
 setenv PANDA_PYTHONPATH `bash ${PANDA_SYS}/etc/panda/site_path.sh`

--- a/templates/panda_setup.sh.template
+++ b/templates/panda_setup.sh.template
@@ -1,5 +1,11 @@
-export PANDA_SYS=`python3 -c "import sysconfig; print(sysconfig.get_path('data'))"`
-export PATH=`python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"`:$PATH
+# resolve PANDA_SYS from this file's own location rather than a path baked in at
+# build time, since a wheel-installed panda-client may have been built in a
+# temporary, isolated build environment that no longer exists at runtime
+_panda_setup_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+export PANDA_SYS="$(cd "${_panda_setup_dir}/../.." && pwd)"
+unset _panda_setup_dir
+
+export PATH=${PANDA_SYS}/bin:$PATH
 
 export PANDA_CONFIG_ROOT=~/.pathena
 

--- a/templates/panda_setup.sh.template
+++ b/templates/panda_setup.sh.template
@@ -1,7 +1,7 @@
-export PATH=@@install_scripts@@:$PATH
+export PANDA_SYS=`python3 -c "import sysconfig; print(sysconfig.get_path('data'))"`
+export PATH=`python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"`:$PATH
 
 export PANDA_CONFIG_ROOT=~/.pathena
-export PANDA_SYS=@@install_dir@@
 
 export PANDA_PYTHONPATH=`bash ${PANDA_SYS}/etc/panda/site_path.sh`
 

--- a/templates/site_path.sh.template
+++ b/templates/site_path.sh.template
@@ -3,7 +3,5 @@
 source ${PANDA_SYS}/etc/panda/share/functions.sh
 
 exec_p_command \
-"import sys; import os.path; "\
-"s_path='@@install_dir@@/lib/python{0}.{1}/site-packages'.format(*sys.version_info); "\
-"s_path = s_path if os.path.exists(s_path) else '@@install_purelib@@'; "\
-"print(s_path)"
+"import sysconfig; "\
+"print(sysconfig.get_path('purelib'))"

--- a/templates/site_path.sh.template
+++ b/templates/site_path.sh.template
@@ -1,7 +1,22 @@
 #!/bin/bash
 
-source ${PANDA_SYS}/etc/panda/share/functions.sh
-
-exec_p_command \
-"import sysconfig; "\
-"print(sysconfig.get_path('purelib'))"
+# find this install's site-packages directory relative to PANDA_SYS rather than
+# asking whatever python happens to be on PATH, which may not be the interpreter
+# panda-client was actually installed for (e.g. a --prefix install into a
+# non-activated environment)
+shopt -s nullglob
+candidates=(${PANDA_SYS}/lib/python*/site-packages ${PANDA_SYS}/lib64/python*/site-packages)
+s_path=""
+for c in "${candidates[@]}"; do
+    if [ -d "${c}/pandaclient" ]; then
+        s_path="$c"
+        break
+    fi
+done
+if [ -z "$s_path" ] && [ ${#candidates[@]} -gt 0 ]; then
+    s_path="${candidates[0]}"
+fi
+if [ -z "$s_path" ]; then
+    s_path="${PANDA_SYS}/lib/site-packages"
+fi
+echo "$s_path"


### PR DESCRIPTION
Fixes #100.

Root cause: hatch_build.py's initialize() calls sysconfig.get_path() at wheel build time. Any installer using PEP 517 build isolation (uv, pixi, and modern pip by default) builds the wheel inside a throwaway temporary virtualenv, so that path is baked into panda_setup.sh/csh and site_path.sh pointing at a directory that no longer exists once the wheel is actually installed. This isn't specific to uv/pixi — it reproduces with a plain isolated `pip wheel .` build too, and likely affects `pip install .` on modern pip as well, since pip also builds via an isolated backend by default.

Fix: instead of trying to predict the install location at build time, resolve it at the point the file is actually used:
- panda_setup.sh/csh now compute PANDA_SYS and the scripts directory via a `python3 -c "import sysconfig; ..."` lookup executed when the file is sourced. This mirrors the pattern the docs already use to locate the setup file itself (`` source `python -c "import sys; print(sys.prefix)"`/etc/panda/panda_setup.sh ``) — just moved inside the script so it no longer needs to be baked in.
- site_path.sh now calls `sysconfig.get_path('purelib')` directly (via the same exec_p_command interpreter-selection logic already used elsewhere in the script) instead of choosing between two candidate paths that were both derived from the same build-time value.
- panda_jupyter.py's setup() had the identical problem reading PANDA_INSTALL_SCRIPTS/PURELIB/DIR from ~/.panda/panda_setup.cfg (generated by the same build hook), so it now resolves those from sysconfig in the running interpreter instead of trusting the file.

hatch_build.py itself is untouched — the PANDA_INSTALL_TARGET override and the RPM/bdist buildroot-stripping logic it still uses for panda_setup.example.cfg's substitution are unaffected, since that file's baked values are no longer functionally read by panda_jupyter.py either way.

Verified concretely:
- Built a wheel via an isolated PEP 517 build (`pip wheel .`), confirmed the shipped panda_setup.sh contained a bogus temp build path before this change.
- With the fix, installed that wheel into a separate fresh venv and sourced panda_setup.sh: PANDA_SYS/PATH/PYTHONPATH all correctly resolved to the venv's own prefix, pathena and prun found on PATH.
- Re-verified the documented `pip install .` flow (README/docs' primary install method) still resolves correctly — no regression there.
- black/isort pass via pre-commit.